### PR TITLE
#15129

### DIFF
--- a/ItaCH_Smash_Legends/Assets/PlayerInput.inputactions
+++ b/ItaCH_Smash_Legends/Assets/PlayerInput.inputactions
@@ -2,7 +2,7 @@
     "name": "PlayerInput",
     "maps": [
         {
-            "name": "PlayerActions",
+            "name": "FirtstPlayerActions",
             "id": "49f181af-877a-4d06-b914-d4b226d8df57",
             "actions": [
                 {
@@ -124,6 +124,138 @@
                     "name": "",
                     "id": "1ada06a1-1c08-4a94-afef-b92ac634e01c",
                     "path": "<Keyboard>/x",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "PC",
+                    "action": "SmashAttack",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                }
+            ]
+        },
+        {
+            "name": "SecondPlayerActions",
+            "id": "14253c08-3744-4299-b05f-360ba38ed538",
+            "actions": [
+                {
+                    "name": "Move",
+                    "type": "Value",
+                    "id": "30a3c280-5330-42b5-8272-b0a2dc236ceb",
+                    "expectedControlType": "Vector2",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                },
+                {
+                    "name": "Jump",
+                    "type": "Button",
+                    "id": "56c66e86-ccd1-422f-8ae2-a1354d0969f8",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "DefaultAttack",
+                    "type": "Button",
+                    "id": "158d8d14-7a9e-4de8-876f-203f15219059",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "SmashAttack",
+                    "type": "Button",
+                    "id": "356af590-fdfa-4ef8-8a7b-8ab230bcb3c5",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                }
+            ],
+            "bindings": [
+                {
+                    "name": "Direction",
+                    "id": "edd6c318-6194-44e7-b9c1-e1a7a00a40c7",
+                    "path": "2DVector",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Move",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "up",
+                    "id": "c56f3e16-385f-466f-9fed-e0f561ebfc82",
+                    "path": "<Keyboard>/t",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "PC",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "down",
+                    "id": "45a1baad-2097-48a4-b5cc-bcf4e0939d82",
+                    "path": "<Keyboard>/g",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "PC",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "left",
+                    "id": "ef65904a-99e8-4bd6-95dd-d49f4c7921fd",
+                    "path": "<Keyboard>/f",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "PC",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "right",
+                    "id": "46f8e09d-8fb5-4706-a7d2-51dbc55c1ed6",
+                    "path": "<Keyboard>/h",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "PC",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "",
+                    "id": "e059e9be-2e0e-43a5-9d17-d01339d3fd54",
+                    "path": "<Keyboard>/d",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "PC",
+                    "action": "Jump",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "95275af9-d460-4afe-aa2f-cc5a0381fef0",
+                    "path": "<Keyboard>/a",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "PC",
+                    "action": "DefaultAttack",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "30a38c83-91a7-4394-8139-c95b17540b85",
+                    "path": "<Keyboard>/s",
                     "interactions": "",
                     "processors": "",
                     "groups": "PC",


### PR DESCRIPTION
인풋시스템 -> 2P 플레이어 키입력 추가

# PR을 하기 전 체크사항

<!-- PR 전에 아래의 내용을 수행했는지 하나씩 체크해봅시다. 체크 표시는 []에 x를 넣어 [x]로 만들면 됩니다. 자세한 건 [여기](https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists)를 참고하세요 -->
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능

<!-- 달라진 기능에는 무엇이 있는지 목록으로 작성합니다. 이번 작업 내용을 통해 할 수 있는 기능 및 행동 등을 설명해주세요-->
- 프로토타입 2P Player 키 입력기능 추가

# 제안 사항

<!--위의 기능을 달성하기 위해 프로젝트에 어떤 변화를 주었는지 작성합니다. 어떤 코드 작성 혹은 패키지 혹은 인스펙터값 조정 등 실제 작업한 내용을 여기에 적으세요-->
- 목록 Input System -> Action Maps 에서 기존 Player Action 에서 FirstPlayerAction 과 SecondPlayer Action 으로 변동
> 이유 해당 Action Maps 을 기준으로 프리팹 Player Input 에서 Default Map 수정으로 키입력 분리 가능

# 스크린샷 <!--여기 스크린샷 첨부하고 (선택) 이거는 지워주세요-->
이 기능과 관련된 스크린샷을 추가합니다. 

![기존](https://github.com/KIA-PROGRAMMING-38/Team_ItaCH_SmashLegends/assets/118022787/cceb227c-4e4e-40d8-8080-af109a705cea)

[변경 후 ]
![image](https://github.com/KIA-PROGRAMMING-38/Team_ItaCH_SmashLegends/assets/118022787/8847af98-c9e9-41bf-99e3-1f91e3f26d27)

인스펙터
![image](https://github.com/KIA-PROGRAMMING-38/Team_ItaCH_SmashLegends/assets/118022787/1b9150e7-220b-423b-a07f-cc7a5a193eff)

