### PR TITLE
[Feat] Implement End Game with time-over

### DIFF
--- a/ItaCH_Smash_Legends/Assets/Script/Player_Status/CharacterStatus.cs
+++ b/ItaCH_Smash_Legends/Assets/Script/Player_Status/CharacterStatus.cs
@@ -49,6 +49,6 @@ public class CharacterStatus : CharacterDefaultStatus
         this.transform.position = _spawnPoint;
         this.gameObject.SetActive(true);
         this.GetComponent<Collider>().isTrigger = false;
-        InitHP();
+        InitHP();        
     }
 }

--- a/ItaCH_Smash_Legends/Assets/Script/Stage/GameMode.cs
+++ b/ItaCH_Smash_Legends/Assets/Script/Stage/GameMode.cs
@@ -9,7 +9,7 @@ public class GameMode
     public GameObject Map { get => _currentMap; private set => _currentMap = value; }
     public int TotalPlayer { get => _totalPlayer; private set => _totalPlayer = value; }
     public int TeamSize { get => _teamSize; private set => _teamSize = value; }
-    public float MaxGameTime { get => _maxGameTime; private set => _maxGameTime = value; }
+    public int MaxGameTime { get => _maxGameTimeSec; private set => _maxGameTimeSec = value; }
     public int WinningScore { get => _winningScore; private set => _winningScore = value; }
     public Transform[] SpawnPoints { get => _spawnPoints; private set => _spawnPoints = value; }
     
@@ -18,7 +18,7 @@ public class GameMode
     private int _totalPlayer;
     private int _teamSize;
     private int _winningScore;
-    private float _maxGameTime;
+    private int _maxGameTimeSec;
     private Transform[] _spawnPoints;
 
     public void InitGameMode(GameModeType gameModeType)
@@ -32,7 +32,7 @@ public class GameMode
         _currentGameModeType = gameModeType;
         _totalPlayer = 2;
         _teamSize = 1;
-        _maxGameTime = 120f;
+        _maxGameTimeSec = 120;
         _winningScore = 3;
         // 현재 Duel Mode 값 직접 지정
     }


### PR DESCRIPTION
# PR을 하기 전 체크사항

<!-- PR 전에 아래의 내용을 수행했는지 하나씩 체크해봅시다. 체크 표시는 []에 x를 넣어 [x]로 만들면 됩니다. 자세한 건 [여기](https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists)를 참고하세요 -->
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능

<!-- 달라진 기능에는 무엇이 있는지 목록으로 작성합니다. 이번 작업 내용을 통해 할 수 있는 기능 및 행동 등을 설명해주세요-->
- 목록 1 모드에서 정해진 최대 시간을 현재 시간이 초과하는 경우 게임이 종료됩니다.
- 목록 2 게임이 종료되었을 때 양팀의 승점이 동일하다면 체력 비율을 확인하여 큰 쪽이 승리합니다.
- 목록 3 양팀의 체력 비율이 동일하다면 무승부 처리 됩니다.

# 제안 사항

<!--위의 기능을 달성하기 위해 프로젝트에 어떤 변화를 주었는지 작성합니다. 어떤 코드 작성 혹은 패키지 혹은 인스펙터값 조정 등 실제 작업한 내용을 여기에 적으세요-->
- 목록 1 게임 시간을 프레임 단위로 실행하는 코루틴이 추가되었습니다.
> 이유 폴링없이 게임 시간을 누적하기 위함입니다. 
- 목록 2 게임 시간을 저장하는 변수가 float에서 int로 변경되었습니다.
> 이유 Mode UI와 연결을 용이하게 하기 위해 반영되었습니다.
- 목록 3 스테이지 매니저가 각 팀에 대한 스탯 정보를 가지고 있습니다.
> 이유 인덱스로 멤버를 접근하여 체력 비율을 판별합니다.

# 스크린샷 <!--여기 스크린샷 첨부하고 (선택) 이거는 지워주세요-->


![TimeOver](https://github.com/KIA-PROGRAMMING-38/Team_ItaCH_SmashLegends/assets/120005138/8b26114c-4f6f-4ac5-8052-141b9842f15b)
![Draw](https://github.com/KIA-PROGRAMMING-38/Team_ItaCH_SmashLegends/assets/120005138/294c04ea-6fa8-40a8-8250-258955037db6)

