### PR TITLE
#13262

### DIFF
--- a/ItaCH_Smash_Legends/Assets/Animator/Peter/Peter_SkillAttack.anim
+++ b/ItaCH_Smash_Legends/Assets/Animator/Peter/Peter_SkillAttack.anim
@@ -84546,6 +84546,13 @@ AnimationClip:
     intParameter: 0
     messageOptions: 0
   - time: 1.4333333
+    functionName: ChangeSkillEndAttackStatus
+    data: 
+    objectReferenceParameter: {fileID: 0}
+    floatParameter: 0
+    intParameter: 0
+    messageOptions: 0
+  - time: 1.4333333
     functionName: EnableEndSkillAttackEffect
     data: 
     objectReferenceParameter: {fileID: 0}

--- a/ItaCH_Smash_Legends/Assets/Scenes/Alice.unity
+++ b/ItaCH_Smash_Legends/Assets/Scenes/Alice.unity
@@ -306,7 +306,7 @@ PrefabInstance:
     - target: {fileID: 1801810034622763240, guid: 6b1442466a235874686d9585788f272f,
         type: 3}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1801810034622763246, guid: 6b1442466a235874686d9585788f272f,
         type: 3}
@@ -593,6 +593,11 @@ PrefabInstance:
     - target: {fileID: 8764072940790701996, guid: e3ee9b69ab5171641abfb8bf06a2db63,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9218375918672409366, guid: e3ee9b69ab5171641abfb8bf06a2db63,
+        type: 3}
+      propertyPath: m_Enabled
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []

--- a/ItaCH_Smash_Legends/Assets/Script/Alice/AliceHit.cs
+++ b/ItaCH_Smash_Legends/Assets/Script/Alice/AliceHit.cs
@@ -9,24 +9,23 @@ public class AliceHit : PlayerHit
         Vector3 heavyAttackKnockbackDirection = transform.up + transform.forward;
         lightKnockbackPower = 0.8f;
         heavyKnockbackPower = 0.8f;
-        if (!invincible)
+
+        switch (_playerStatus.CurrentState)
         {
-            switch (_playerStatus.CurrentState)
-            {
-                case PlayerStatus.State.SkillEndAttack:
-                    SkillAttackHit(other).Forget();
-                    break;
-                case PlayerStatus.State.ComboAttack:
-                    GetHit(defaultAttackKnockbackDirection, lightKnockbackPower, AnimationHash.Hit, other);
-                    break;
-                case PlayerStatus.State.FinishComboAttack:
-                    GetHit(heavyAttackKnockbackDirection, heavyKnockbackPower, AnimationHash.HitUp, other);
-                    break;
-                case PlayerStatus.State.JumpAttack:
-                    GetHit(heavyAttackKnockbackDirection, heavyKnockbackPower, AnimationHash.HitUp, other);
-                    break;
-            }
+            case PlayerStatus.State.SkillAttack:
+                SkillAttackHit(other).Forget();
+                break;
+            case PlayerStatus.State.ComboAttack:
+                GetHit(defaultAttackKnockbackDirection, lightKnockbackPower, AnimationHash.Hit, other);
+                break;
+            case PlayerStatus.State.FinishComboAttack:
+                GetHit(heavyAttackKnockbackDirection, heavyKnockbackPower, AnimationHash.HitUp, other);
+                break;
+            case PlayerStatus.State.JumpAttack:
+                GetHit(heavyAttackKnockbackDirection, heavyKnockbackPower, AnimationHash.HitUp, other);
+                break;
         }
+
     }
 
     private async UniTask SkillAttackHit(Collider other)

--- a/ItaCH_Smash_Legends/Assets/Script/Peter/PeterAttack.cs
+++ b/ItaCH_Smash_Legends/Assets/Script/Peter/PeterAttack.cs
@@ -56,4 +56,5 @@ public class PeterAttack : PlayerAttack
 
     public void EnableSkillAttackHitZone() => _skillAttackHitZone.enabled = true;
     public void DisableSkillAttackHitZone() => _skillAttackHitZone.enabled = false;
+    public void ChangeSkillEndAttackStatus() => playerStatus.CurrentState = PlayerStatus.State.SkillEndAttack;
 }

--- a/ItaCH_Smash_Legends/Assets/Script/Player_State/PlayerIdleState.cs
+++ b/ItaCH_Smash_Legends/Assets/Script/Player_State/PlayerIdleState.cs
@@ -4,14 +4,12 @@ public class PlayerIdleState : StateMachineBehaviour
 {
     private PlayerStatus _playerStatus;
     private PlayerMove _playerMove;
-    private PlayerHit _playerHit;
     private PlayerAttack _playerAttack;
 
     override public void OnStateEnter(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
     {
         _playerMove = animator.GetComponent<PlayerMove>();
         _playerStatus = animator.GetComponent<PlayerStatus>();
-        _playerHit = animator.GetComponent<PlayerHit>();
         _playerAttack = animator.GetComponent<PlayerAttack>();
 
         _playerStatus.CurrentState = PlayerStatus.State.Idle;
@@ -20,6 +18,7 @@ public class PlayerIdleState : StateMachineBehaviour
         _playerStatus.IsHang = false;
 
         _playerAttack.CurrentPossibleComboCount = _playerAttack.MAX_POSSIBLE_ATTACK_COUNT;
+
         if (_playerMove.moveDirection != Vector3.zero)
         {
             animator.SetBool(AnimationHash.Run, true);

--- a/ItaCH_Smash_Legends/Assets/Script/Player_State/PlayerRunState.cs
+++ b/ItaCH_Smash_Legends/Assets/Script/Player_State/PlayerRunState.cs
@@ -3,14 +3,12 @@ using UnityEngine;
 public class PlayerRunState : StateMachineBehaviour
 {
     private PlayerMove _playerMove;
-    private PlayerAttack _playerAttack;
     private PlayerStatus _playerStatus;
 
     override public void OnStateEnter(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
     {
         _playerStatus = animator.GetComponent<PlayerStatus>();
         _playerMove = animator.GetComponent<PlayerMove>();
-        _playerAttack = animator.GetComponent<PlayerAttack>();
         _playerStatus.CurrentState = PlayerStatus.State.Run;
     }
 

--- a/ItaCH_Smash_Legends/Assets/Script/Player_State/PlayerSkillAttackState.cs
+++ b/ItaCH_Smash_Legends/Assets/Script/Player_State/PlayerSkillAttackState.cs
@@ -10,15 +10,12 @@ public class PlayerSkillAttackState : StateMachineBehaviour
 
     override public void OnStateUpdate(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
     {
-        if (animator.GetCurrentAnimatorStateInfo(0).normalizedTime > 0.35f)
-        {
-            _playerStatus.CurrentState = PlayerStatus.State.SkillEndAttack;
-        }
+        
     }
 
     override public void OnStateExit(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
     {
-
+        
     }
 
 }


### PR DESCRIPTION
# PR을 하기 전 체크사항

<!-- PR 전에 아래의 내용을 수행했는지 하나씩 체크해봅시다. 체크 표시는 []에 x를 넣어 [x]로 만들면 됩니다. 자세한 건 [여기](https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists)를 참고하세요 -->
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능

<!-- 달라진 기능에는 무엇이 있는지 목록으로 작성합니다. 이번 작업 내용을 통해 할 수 있는 기능 및 행동 등을 설명해주세요-->
- 목록 1 PlayerSkillAttackState 스크립트에서 스킬어택을 정의해주는 것을 삭제
- 목록 2 AliceHit 스크립트에서 SkillAttack 관련 수정
- 목록 3 PeterAttack 스크립트에서 애니메이션 이벤트함수로 쓰일 함수 생성 후 PeterHit 스크립트에서 관련사항 수정

# 제안 사항

<!--위의 기능을 달성하기 위해 프로젝트에 어떤 변화를 주었는지 작성합니다. 어떤 코드 작성 혹은 패키지 혹은 인스펙터값 조정 등 실제 작업한 내용을 여기에 적으세요-->
- 목록 1 PlayerSkillAttackState 스크립트에서 OnStateUpdate에서 정의해준 조건문을 삭제하였습니다.
> 공통적인 로직이 아닌 피터만을 위한 로직이기때문에 취지와 맞지 않아 삭제하였습니다.
- 목록 2 AliceHit 스크립트에서 조건문에서 SkillEndAttack을 SkillAttack으로 수정하였습니다. 
> 앨리스의 경우 SkillEndAttack 보다는 SkillAttack으로 피격을 판정하기 때문에 수정하였습니다.
- 목록 3 PeterAttack 스크립트에서 애니메이션 이벤트를 통해 피터가 스킬어택마무리공격을 할 때 상태를 SkillEndAttack을 생성하였습니다.
> 기존의 SkillAttackState에서 정의해준 SkillEndAttack을 삭제 후 이벤트 함수를 통해 같이 활성화되도록 하였습니다.

# 스크린샷 <!--여기 스크린샷 첨부하고 (선택) 이거는 지워주세요-->
- Peter SkillEndAttack을 애니메이션 이벤트를 적용한 모습
![image](https://github.com/KIA-PROGRAMMING-38/Team_ItaCH_SmashLegends/assets/120005279/f69632d0-0dcb-4de8-9de8-38127058298b)
![image](https://github.com/KIA-PROGRAMMING-38/Team_ItaCH_SmashLegends/assets/120005279/710583c2-8c31-4784-9f20-e0e7fabb0974)


