### PR TITLE
#15313

### DIFF
--- a/ItaCH_Smash_Legends/Assets/Script/Player_Status/CharacterStatus.cs
+++ b/ItaCH_Smash_Legends/Assets/Script/Player_Status/CharacterStatus.cs
@@ -40,7 +40,7 @@ public class CharacterStatus : CharacterDefaultStatus
     private int _currentHealthPointRatio;
     private float _currentRespawnTime;
     private const int DEAD_TRIGGER_HP = 0;
-    private bool _isDead = false;
+    internal bool _isDead = false;
 
     public event Action<int, int> OnPlayerHealthPointChange;
     public event Action<CharacterStatus> OnPlayerDie;
@@ -138,7 +138,6 @@ public class CharacterStatus : CharacterDefaultStatus
         OnPlayerHealthPointChange.Invoke(_currentHealthPoint, _currentHealthPointRatio);
         if (_currentHealthPoint <= DEAD_TRIGGER_HP && !this._isDead)
         {
-            this._isDead = true;
             OnPlayerDie.Invoke(this);
             OnPlayerDieSmokeEffect.Invoke();
         }

--- a/ItaCH_Smash_Legends/Assets/Script/Stage/DeadZone.cs
+++ b/ItaCH_Smash_Legends/Assets/Script/Stage/DeadZone.cs
@@ -11,6 +11,7 @@ public class DeadZone : MonoBehaviour
         }
         else
         {
+            playerCharacter._isDead = true;
             playerCharacter.gameObject.SetActive(false);
         }
     }


### PR DESCRIPTION
캐릭터가 데드존에 닿았을시 이펙트를 출력합니다.

# PR을 하기 전 체크사항

<!-- PR 전에 아래의 내용을 수행했는지 하나씩 체크해봅시다. 체크 표시는 []에 x를 넣어 [x]로 만들면 됩니다. 자세한 건 [여기](https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists)를 참고하세요 -->
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능

<!-- 달라진 기능에는 무엇이 있는지 목록으로 작성합니다. 이번 작업 내용을 통해 할 수 있는 기능 및 행동 등을 설명해주세요-->
- 기존에 구현된 사망 이펙트가 출력되지 않던 현상을 수정합니다. 
- 캐릭터가 데드존에 닿았을시 사망 이펙트가 출력됩니다.


# 제안 사항

<!--위의 기능을 달성하기 위해 프로젝트에 어떤 변화를 주었는지 작성합니다. 어떤 코드 작성 혹은 패키지 혹은 인스펙터값 조정 등 실제 작업한 내용을 여기에 적으세요-->
- Character Status 스크립트의 isDead 변수를 외부에 공개합니다.
> Dead Zone 에서 이를 수정하며 해당 캐릭터의 상태를 false 로 변환합니다.
> 수정된 isDead 변수로 OnDisable 때 이펙트를 출력합니다.
- Character Status 스크립트의 GetDamage 함수에서 isDead 변수 변환을 제거했습니다.
> Dead Zone 에서 이를 수정하기에 불필요한 코드로 판단, 해당 코드를 제거합니다.

# 스크린샷 <!--여기 스크린샷 첨부하고 (선택) 이거는 지워주세요-->


https://github.com/KIA-PROGRAMMING-38/Team_ItaCH_SmashLegends/assets/118022787/06b89e47-bc76-4220-aee2-64fb1a03d7c3

