### PR TITLE
#15314

### DIFF
--- a/ItaCH_Smash_Legends/Assets/Scenes/Hook.unity
+++ b/ItaCH_Smash_Legends/Assets/Scenes/Hook.unity
@@ -195,6 +195,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: Peter_Ingame (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 1801810034622763246, guid: 6b1442466a235874686d9585788f272f,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6b1442466a235874686d9585788f272f, type: 3}
 --- !u!1001 &52416001
@@ -655,6 +660,11 @@ PrefabInstance:
       propertyPath: m_Layer
       value: 7
       objectReference: {fileID: 0}
+    - target: {fileID: 8280973247567168790, guid: e3ee9b69ab5171641abfb8bf06a2db63,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8364983912144816812, guid: e3ee9b69ab5171641abfb8bf06a2db63,
         type: 3}
       propertyPath: m_Layer
@@ -896,7 +906,7 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &269641501
+--- !u!1 &132276754
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -904,22 +914,22 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 269641502}
-  - component: {fileID: 269641503}
-  m_Layer: 0
+  - component: {fileID: 132276755}
+  - component: {fileID: 132276756}
+  m_Layer: 7
   m_Name: GameObject
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &269641502
+--- !u!4 &132276755
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 269641501}
+  m_GameObject: {fileID: 132276754}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.0276, y: 0, z: 0}
   m_LocalScale: {x: 0.01, y: 0.01, z: 0.01}
@@ -928,13 +938,13 @@ Transform:
   m_Father: {fileID: 1881243128}
   m_RootOrder: 18
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &269641503
+--- !u!114 &132276756
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 269641501}
+  m_GameObject: {fileID: 132276754}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 35dd08ea9a28ed946b15f1e478bacdf8, type: 3}
@@ -992,6 +1002,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 1629445725069444990, guid: 0a820f92e71e03e42a7435b844051544,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 6047655085950843869, guid: 0a820f92e71e03e42a7435b844051544,
         type: 3}
       propertyPath: m_RootOrder
@@ -1046,6 +1061,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081881771450060189, guid: 0a820f92e71e03e42a7435b844051544,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6387871113122111847, guid: 0a820f92e71e03e42a7435b844051544,
         type: 3}
@@ -1141,6 +1161,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: Peter_Ingame (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1801810034622763246, guid: 6b1442466a235874686d9585788f272f,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6b1442466a235874686d9585788f272f, type: 3}
@@ -2109,6 +2134,11 @@ PrefabInstance:
       propertyPath: m_Layer
       value: 7
       objectReference: {fileID: 0}
+    - target: {fileID: 8280973247567168790, guid: e3ee9b69ab5171641abfb8bf06a2db63,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8364983912144816812, guid: e3ee9b69ab5171641abfb8bf06a2db63,
         type: 3}
       propertyPath: m_Layer
@@ -2797,6 +2827,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Layer
       value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 6387871113122111847, guid: 0a820f92e71e03e42a7435b844051544,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6469862050080975118, guid: 0a820f92e71e03e42a7435b844051544,
         type: 3}

--- a/ItaCH_Smash_Legends/Assets/Script/Hook/HookAttack.cs
+++ b/ItaCH_Smash_Legends/Assets/Script/Hook/HookAttack.cs
@@ -34,6 +34,8 @@ public class HookAttack : PlayerAttack
     private int _lastHeavyFireEffect = 2;
 
     private float _jumpRotateValue = 45f;
+    private float _defaultDashPower;
+    private float _heavyDashPower;
 
     private Vector3 _jumpUpDashPower = new Vector3(0, 0.3f, 0);
     private Vector3 _jumpDashPower;
@@ -61,8 +63,8 @@ public class HookAttack : PlayerAttack
     };
     private void Start()
     {
-        CreateObjectPool();
         nextTransitionMinValue = 0.6f;
+
         _bulletSpawnPositionLeft = transform.GetChild(_rootIndex).GetChild(_boneIndex).GetChild(_leftWeaponIndex).GetChild(_cylinderIndex).transform;
         _bulletSpawnPositionRight = transform.GetChild(_rootIndex).GetChild(_boneIndex).GetChild(_rightWeaponIndex).GetChild(_cylinderIndex).transform;
         for (int i = 0; i < _bulletContainers.Length; ++i)
@@ -70,11 +72,15 @@ public class HookAttack : PlayerAttack
             _bulletContainers[i] = transform.GetChild(i).gameObject;
             _bullets[i] = _bulletContainers[i].transform.GetChild(0).GetComponent<HookBullet>();
         }
-            _bulletCreateEffects[_defaultFireEffect] = _bulletContainers[_defaultIndex].transform.GetChild(1).GetComponent<FireEffect>();
+        _bulletCreateEffects[_defaultFireEffect] = _bulletContainers[_defaultIndex].transform.GetChild(1).GetComponent<FireEffect>();
         _bulletCreateEffects[_heavyFireEffect] = _bulletContainers[_heavyIndex].transform.GetChild(1).GetComponent<FireEffect>();
         _bulletCreateEffects[_lastHeavyFireEffect] = _bulletContainers[_lastHeavyIndex].transform.GetChild(1).GetComponent<FireEffect>();
 
+        CreateObjectPool();
         _shotEffect = Parrot.transform.GetChild(0).GetComponent<ParticleSystem>();
+        
+        _defaultDashPower = defaultDashPower * -0.4f;
+        _heavyDashPower = defaultDashPower * -0.65f;
     }
     private void OnDisable()
     {
@@ -87,13 +93,13 @@ public class HookAttack : PlayerAttack
     {
         if (CurrentPossibleComboCount == COMBO_FINISH_COUNT && playerStatus.CurrentState == PlayerStatus.State.ComboAttack)
         {
-            rigidbodyAttack.AddForce(transform.forward * (defaultDashPower * -0.4f), ForceMode.Impulse);
+            rigidbodyAttack.AddForce(transform.forward * (_defaultDashPower), ForceMode.Impulse);
 
         }
         if (CurrentPossibleComboCount == MAX_POSSIBLE_ATTACK_COUNT &&
             playerStatus.CurrentState == PlayerStatus.State.HeavyAttack)
         {
-            rigidbodyAttack.AddForce(transform.forward * (defaultDashPower * -0.65f), ForceMode.Impulse);
+            rigidbodyAttack.AddForce(transform.forward * (_heavyDashPower ), ForceMode.Impulse);
         }
 
         if (playerStatus.IsJump == false)

--- a/ItaCH_Smash_Legends/Assets/Script/Hook/HookBullet.cs
+++ b/ItaCH_Smash_Legends/Assets/Script/Hook/HookBullet.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 using UnityEngine.Pool;
 public class HookBullet : MonoBehaviour
 {
+    protected BulletDeleteEffect bulletDeleteEffect;
     protected const float DEFAULT_BULLET_SPEED = 20f;
     protected const float HEAVY_BULLET_SPEED = 28f;
     protected const float DEFAULT_BULLET_DELETE_TIME = 0.23f;
@@ -18,17 +19,16 @@ public class HookBullet : MonoBehaviour
     protected string bulletDeleteEffectPath = "Charater/Hook/Hook_Ingame/Hook_Default_Bullet_Delete_Effect";
 
     public ObjectPool<HookBullet> Pool { get; set; }
-    private ObjectPool<BulletDeleteEffect> _bulletDeleteEffectPool;
-    private float _elapsedTime;
-
     internal GameObject constructor;
 
-    protected BulletDeleteEffect bulletDeleteEffect;
+    private ObjectPool<BulletDeleteEffect> _bulletDeleteEffectPool;
+    private float _elapsedTime;
 
     private void Start()
     {
         bulletDeleteEffect = Resources.Load<BulletDeleteEffect>(bulletDeleteEffectPath);
-        _bulletDeleteEffectPool = new ObjectPool<BulletDeleteEffect>(CreateBulletDeleteEffectOnPool, GetPoolBulletDeleteEffect, ReturnBulletDeleteEffect, (effect) => Destroy(effect), true, 10, 500);
+        _bulletDeleteEffectPool = new ObjectPool<BulletDeleteEffect>(CreateBulletDeleteEffectOnPool,
+            GetPoolBulletDeleteEffect, ReturnBulletDeleteEffect, (effect) => Destroy(effect), true, 10, 500);
     }
 
     private void Update()

--- a/ItaCH_Smash_Legends/Assets/Script/Hook/HookHeavyHit.cs
+++ b/ItaCH_Smash_Legends/Assets/Script/Hook/HookHeavyHit.cs
@@ -1,6 +1,6 @@
 public class HookHeavyHit : HookHit
 {
-    void Start()
+    protected override void CalculationPowerAndDamage()
     {
         defaultdamage = heavyDamage;
         knockbackPower = heavyKnockbackPower;

--- a/ItaCH_Smash_Legends/Assets/Script/Hook/HookHit.cs
+++ b/ItaCH_Smash_Legends/Assets/Script/Hook/HookHit.cs
@@ -21,14 +21,18 @@ public class HookHit : MonoBehaviour
     private CharacterStatus _characterStatus;
     private PlayerHit _playerHit;
 
-    private void Awake()
+    private void Start()
     {
-        _hookBullet = transform.GetParentComponent<HookBullet>();
-        //_characterStatus = _hookBullet.constructor.gameObject.GetComponent<CharacterStatus>();
-        //SetPowerAndDamage();
+        _hookBullet = GetComponentInParent<HookBullet>();
+        _characterStatus = _hookBullet.constructor.GetComponent<CharacterStatus>();
+        SetPowerAndDamage();
         knockbackPower = defaultKnockbackPower;
+        CalculationPowerAndDamage();
     }
+    protected virtual void CalculationPowerAndDamage()
+    {
 
+    }
     private void SetPowerAndDamage()
     {
         defaultKnockbackPower = _characterStatus.DefaultKnockbackPower;
@@ -53,7 +57,7 @@ public class HookHit : MonoBehaviour
                     GetBulletKnockBack(other);
                     _effectController.StartHitFlashEffet().Forget();
                 }
-                //GetHitDamage(other);
+                GetHitDamage(other);
                 _hookBullet.BulletPostProcessing(BulletDeleteEffectPosition(other));
             }
         }

--- a/ItaCH_Smash_Legends/Assets/Script/Hook/HookSkillHit.cs
+++ b/ItaCH_Smash_Legends/Assets/Script/Hook/HookSkillHit.cs
@@ -1,6 +1,6 @@
 public class HookSkillHit : HookHit
 {
-    void Start()
+    protected override void CalculationPowerAndDamage()
     {
         defaultdamage = skillDamage;
         knockbackUpDirection = skillKnockbackUpDirection;

--- a/ItaCH_Smash_Legends/Assets/Script/PlayerAttack.cs
+++ b/ItaCH_Smash_Legends/Assets/Script/PlayerAttack.cs
@@ -33,14 +33,19 @@ public class PlayerAttack : MonoBehaviour, IAttack
         playerStatus = GetComponent<PlayerStatus>();
         animator = GetComponent<Animator>();
 
+        CurrentPossibleComboCount = MAX_POSSIBLE_ATTACK_COUNT;
+    }
+    private void Start()
+    {
+        SetStatus();
+    }
+    private void SetStatus()
+    {
         defaultDashPower = characterStatus.DashPower;
         heavyCooltime = characterStatus.HeavyCooltime;
         skillGauage = characterStatus.SkillGauage;
         skillGauageRecovery = characterStatus.SkillGauageRecovery;
-        
-        CurrentPossibleComboCount = MAX_POSSIBLE_ATTACK_COUNT;
     }
-
     public void AttackRotate()
     {
         if (playerMove.moveDirection != Vector3.zero)


### PR DESCRIPTION
기존 오류 발생했던 후크 관련 데이터 연동 구현 과 데이터 연동 확인중 Attack 에서 동일한 오류가 발생하여 같이 수정합니다.

# PR을 하기 전 체크사항

<!-- PR 전에 아래의 내용을 수행했는지 하나씩 체크해봅시다. 체크 표시는 []에 x를 넣어 [x]로 만들면 됩니다. 자세한 건 [여기](https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists)를 참고하세요 -->
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능

<!-- 달라진 기능에는 무엇이 있는지 목록으로 작성합니다. 이번 작업 내용을 통해 할 수 있는 기능 및 행동 등을 설명해주세요-->
- 전체 캐릭터 어택에서 연동되지 않던 데이터가 연동됩니다.
- 후크 캐릭터 Hit 관련 데이터가 연동되지 않던 문제를 수정합니다.

# 제안 사항

<!--위의 기능을 달성하기 위해 프로젝트에 어떤 변화를 주었는지 작성합니다. 어떤 코드 작성 혹은 패키지 혹은 인스펙터값 조정 등 실제 작업한 내용을 여기에 적으세요-->
- PlayerAttack 스크립트에 함수 추가, 이벤트 함수 주기 변경
> 이벤트 함수 호출 순서를 변경하여 데이터 연동을 정상화, 해당 기능들을 메소드로 묶어 모듈화 했습니다.
- HookHit 관련 이벤트 호출 순서 변경, virtual 메소드 추가
> 이벤트 함수 호출 순서를 변경하여 데이터 연동 정상화, virtual로 정상화 한 데이터를 대입합니다.

