### PR TITLE
#12319

### DIFF
--- a/ItaCH_Smash_Legends/Assets/Script/Alice/AliceAttack.cs
+++ b/ItaCH_Smash_Legends/Assets/Script/Alice/AliceAttack.cs
@@ -25,13 +25,14 @@ public class AliceAttack : PlayerAttack
     }
 
     public override void DefaultAttack()
-    {
+    {        
         if (IsPossibleFirstAttack())
         {
+            isFinishAttack = false;
             playerStatus.CurrentState = PlayerStatus.State.ComboAttack;
             AttackOnDash();
             animator.Play(AnimationHash.FirstAttack);
-            --CurrentPossibleComboCount;
+            --CurrentPossibleComboCount;            
         }
         if (isFirstAttack && CurrentPossibleComboCount == COMBO_FINISH_COUNT)
         {

--- a/ItaCH_Smash_Legends/Assets/Script/Hook/HookAttack.cs
+++ b/ItaCH_Smash_Legends/Assets/Script/Hook/HookAttack.cs
@@ -114,6 +114,7 @@ public class HookAttack : PlayerAttack
     {
         if (IsPossibleFirstAttack())
         {
+            isFinishAttack = false;
             playerStatus.CurrentState = PlayerStatus.State.ComboAttack;
             animator.Play(AnimationHash.FirstAttack);
         }

--- a/ItaCH_Smash_Legends/Assets/Script/PlayerAttack.cs
+++ b/ItaCH_Smash_Legends/Assets/Script/PlayerAttack.cs
@@ -74,6 +74,7 @@ public class PlayerAttack : MonoBehaviour, IAttack
     {
         if (IsPossibleFirstAttack())
         {
+            isFinishAttack = false;
             animator.Play(AnimationHash.FirstAttack);
         }
 

--- a/ItaCH_Smash_Legends/Assets/Script/PlayerAttack.cs
+++ b/ItaCH_Smash_Legends/Assets/Script/PlayerAttack.cs
@@ -29,7 +29,7 @@ public class PlayerAttack : MonoBehaviour, IAttack
     {
         playerMove = GetComponent<PlayerMove>();
         rigidbodyAttack = GetComponent<Rigidbody>();
-        characterStatus= GetComponent<CharacterStatus>();
+        characterStatus = GetComponent<CharacterStatus>();
         playerStatus = GetComponent<PlayerStatus>();
         animator = GetComponent<Animator>();
 


### PR DESCRIPTION
# PR을 하기 전 체크사항

<!-- PR 전에 아래의 내용을 수행했는지 하나씩 체크해봅시다. 체크 표시는 []에 x를 넣어 [x]로 만들면 됩니다. 자세한 건 [여기](https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists)를 참고하세요 -->
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능

- Default Attack 실행 이후 자동으로 Combo Attack으로 넘어가는 현상이 해결되었습니다.

# 제안 사항

- 애니메이션 전환 로직에서 체크를 위한 boolean 값 초기화 부분이 추가되었습니다.
> 다른 상태에서 전환이 일어나는 경우 초기화가 일어나지 않아 자동으로 다음 공격으로 이어지는 문제를 해결하였습니다.

# 스크린샷

- 수정 전
![BeforeBug_AdobeExpress](https://github.com/KIA-PROGRAMMING-38/Team_ItaCH_SmashLegends/assets/120005138/cab8daa9-c824-47c2-8e75-98e42d9f23d0)
- 수정 후 
![앨리스_수정_AdobeExpress](https://github.com/KIA-PROGRAMMING-38/Team_ItaCH_SmashLegends/assets/120005138/ec71f589-d109-44d2-b44b-497cde312e86)


# 관련 이슈
- [x] #319 